### PR TITLE
Add support and tests for normalizing URLs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = System._nodeRequire ? System._nodeRequire('path') : require('path-browserify');
+module.exports = System._nodeRequire ? System._nodeRequire('path') : require('./lib/main');

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,19 @@
+var path = Object.create(require('path-browserify'));
+var originalNormalize = path.normalize;
+
+path.normalize = function(p) {
+  var protocol = p.match(/^(https?:\/\/)/);
+  
+  if (protocol) {
+    p = p.substring(protocol[1].length - 1);
+    p = originalNormalize.call(this, p);
+    if (p.indexOf('/') === 0) {
+      p = p.substring(1);
+    }
+    return protocol[1] + p;
+  } 
+  
+  return originalNormalize.call(this, p);
+};
+
+module.exports = path;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,12 @@
 {
   "registry": "npm",
+  "scripts": {
+    "test": "node_modules/.bin/mocha test"
+  },
+  "devDependencies": {
+    "assert": "1.3.0",
+    "mocha": "2.2.4"
+  },
   "dependencies": {
     "path-browserify": "0.0.0"
   }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,13 @@
+{
+    "maxerr"        : 50,       // {int} Maximum error before stopping
+
+    // Enforcing
+    "indent"        : 2,        // {int} Number of spaces to use for indentation
+    "quotmark"      : "single",
+    "strict"        : false,     // true: Requires all functions run in ES5 Strict Mode
+
+    // Environments
+    "mocha"         : true,   // Mocha
+    "node"          : true    // Node.js
+}
+

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--reporter dot
+--ui tdd
+--timeout 120000

--- a/test/normalize.js
+++ b/test/normalize.js
@@ -1,0 +1,26 @@
+var assert = require('assert');
+var path = require('../lib/main');
+
+suite('Normalize', function() {
+    test('should conform to the original specification', function () {
+        [
+            { input: '/foo/bar//baz/asdf/quux/..', output: '/foo/bar/baz/asdf' },
+            { input: '/foo/bar//baz/asdf/', output: '/foo/bar/baz/asdf/' },
+            { input: '/foo/bar///baz/asdf/', output: '/foo/bar/baz/asdf/' },
+            { input: '/foo/bar/baz/asdf', output: '/foo/bar/baz/asdf' }
+        ].forEach(function (data) {
+            assert.equal(path.normalize(data.input), data.output);
+        });
+    });
+
+    test('should handle URLs', function () {
+       [
+            { input: 'http://foo/bar//baz/asdf/quux/..', output: 'http://foo/bar/baz/asdf' },
+            { input: 'http:///foo/bar//baz/asdf/', output: 'http://foo/bar/baz/asdf/' },
+            { input: 'http:///foo/bar///baz/asdf/', output: 'http://foo/bar/baz/asdf/' },
+            { input: 'http:///foo/bar/baz/asdf', output: 'http://foo/bar/baz/asdf' }
+        ].forEach(function (data) {
+            assert.equal(path.normalize(data.input), data.output);
+        }); 
+    });
+});


### PR DESCRIPTION
While tying to get the module d3-geo-projection working with jspm, I found the path.normalize function strips multiple slashes. This is done according to the spec, but it fails when __dirname contains a protocol.

This PR enables the normalize function to handle protocols in URLs.
